### PR TITLE
Add `WebbyServerUpdateTimeout`

### DIFF
--- a/webby.c
+++ b/webby.c
@@ -1289,6 +1289,12 @@ static void wb_update_client(struct WebbyServer *srv, struct WebbyConnectionPrv*
 void
 WebbyServerUpdate(struct WebbyServer *srv)
 {
+  WebbyServerUpdateTimeout(srv, 0);
+}
+
+void
+WebbyServerUpdateTimeout(struct WebbyServer *srv, int timeout_ms)
+{
   int i, count, err;
   webby_socket_t max_socket;
   fd_set read_fds, write_fds, except_fds;
@@ -1324,8 +1330,16 @@ WebbyServerUpdate(struct WebbyServer *srv)
     }
   }
 
-  timeout.tv_sec = 0;
-  timeout.tv_usec = 5;
+  if (0 < timeout_ms)
+  {
+    timeout.tv_sec = timeout_ms / 1000;
+    timeout.tv_usec = (timeout_ms % 1000) * 1000;
+  }
+  else
+  {
+    timeout.tv_sec = 0;
+    timeout.tv_usec = 5;
+  }
 
   err = select((int) (max_socket + 1), &read_fds, &write_fds, &except_fds, &timeout);
 

--- a/webby.h
+++ b/webby.h
@@ -169,6 +169,14 @@ WebbyServerInit(struct WebbyServerConfig *config, void *memory, size_t memory_si
 void
 WebbyServerUpdate(struct WebbyServer *srv);
 
+/*
+ * Update the server. Call frequently (at least once per frame).
+ *
+ * The function will wait IOs for at most the specified timeout.
+ */
+void
+WebbyServerUpdateTimeout(struct WebbyServer *srv, int timeout_ms);
+
 /* Shutdown the server and close all sockets. */
 void
 WebbyServerShutdown(struct WebbyServer *srv);


### PR DESCRIPTION
`WebbyServerUpdateTimeout` can be used instead of a sleep.

This is particularly useful to avoid sleeping an unnecessary amount of times, when requests are pending.